### PR TITLE
Added text file for non applicable tests

### DIFF
--- a/api-examples/notapplicable.txt
+++ b/api-examples/notapplicable.txt
@@ -1,0 +1,13 @@
+[begin control_2k]
+This does not apply to the NATS GO Client
+[end control_2k]
+
+[begin connection_listener]
+There is not a single listener for connection events in the NATS GO Client.
+Instead, you can set individual event handlers using
+- DisconnectHandler(cb ConnHandler)
+- ReconnectHandler(cb ConnHandler)
+- ClosedHandler(cb ConnHandler)
+- DiscoveredServersHandler(cb ConnHandler)
+- ErrorHandler(cb ErrHandler)
+[end connection_listener]


### PR DESCRIPTION
This is used by nats-site to generate examples for the online
documentation. This file will be used to describe not applicable
examples for the GO client.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>