### PR TITLE
Remove close on drain example

### DIFF
--- a/api-examples/drain_conn/main.go
+++ b/api-examples/drain_conn/main.go
@@ -26,8 +26,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer nc.Close()
-
 	// Do something with the connection
 
 	// Drain the connection, which will close it when done.


### PR DESCRIPTION
Drain would close so can omit the defer
/cc @sasbury @kozlovic 